### PR TITLE
Remove redundant `input` method calls

### DIFF
--- a/src/gias3/applications/giashmfinp2surf.py
+++ b/src/gias3/applications/giashmfinp2surf.py
@@ -277,7 +277,6 @@ def main():
             v.start()
             v.scene.background = (0, 0, 0)
 
-            ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 

--- a/src/gias3/applications/giasinpsampledicom.py
+++ b/src/gias3/applications/giasinpsampledicom.py
@@ -304,7 +304,6 @@ def main():
             v.start()
             v.scene.background = (0, 0, 0)
 
-            ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 

--- a/src/gias3/applications/giaspcreg.py
+++ b/src/gias3/applications/giaspcreg.py
@@ -128,7 +128,6 @@ def register(mean_mesh, ssm, target, init_rot, fit_mode, fit_comps,
             v.scene.background = (0, 0, 0)
             v.start()
 
-            ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 

--- a/src/gias3/applications/giasrbfreg.py
+++ b/src/gias3/applications/giasrbfreg.py
@@ -122,7 +122,6 @@ def register(source, target, init_rot, pts_only=False, out=None, view=False, **r
             v.scene.background = (0, 0, 0)
             v.start()
 
-            ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 

--- a/src/gias3/applications/giasrigidreg.py
+++ b/src/gias3/applications/giasrigidreg.py
@@ -129,7 +129,6 @@ def register(reg_method, source, target, init_trans, init_rot, init_s,
             v.scene.background = (0, 0, 0)
             v.start()
 
-            ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 

--- a/src/gias3/applications/giassurfacedistance.py
+++ b/src/gias3/applications/giassurfacedistance.py
@@ -269,11 +269,6 @@ def main():
         V.scene.background = (0, 0, 0)
         visualise(V, surfTest, surfGT, imgTest, imgGT)
 
-        if sys.version_info.major == 2:
-            ret = raw_input('press any key and enter to exit')
-        else:
-            ret = input('press any key and enter to exit')
-
 
 if __name__ == '__main__':
     main()

--- a/src/gias3/applications/giastrainpcashapemodel.py
+++ b/src/gias3/applications/giastrainpcashapemodel.py
@@ -191,10 +191,6 @@ def do_pca(args):
             v.scene.background = tuple(args.bgcolour)
             v.start()
 
-            if sys.version_info.major == 2:
-                ret = raw_input('press any key and enter to exit')
-            else:
-                ret = input('press any key and enter to exit')
         else:
             log.info('Visualisation error: cannot import mayavi')
 


### PR DESCRIPTION
These `input` calls are intended to pause execution so that the `traits` window created by the `FieldVi` `start` method doesn't close immediately. With the latest releases of Python and the `traits` library these calls actually block the `traits` window, causing it to hang. The `start` method has been updated so that these pauses are no longer necessary.

This update is dependent on [this PR](https://github.com/musculoskeletal/gias3.visualisation/pull/2), which contains some additional information on the motivation for these changes.